### PR TITLE
Updates for Tensorflow 2.x

### DIFF
--- a/run.py
+++ b/run.py
@@ -61,9 +61,9 @@ def read_record(record_file):
         while(True):
             (image, image_format, height, width,
              xmin, xmax, ymin, ymax, label) = next_element
-            yield (image, image_format.numpy().decode('ascii'), height,
-                    width, xmin, xmax, ymin, ymax,
-                    label)
+            yield (image.numpy(), image_format.numpy().decode('ascii'), height.numpy(),
+                    width.numpy(), xmin.numpy(), xmax.numpy(), ymin.numpy(), ymax.numpy(),
+                    label.numpy())
     except tf.errors.OutOfRangeError:
         pass
 


### PR DESCRIPTION
Updates for Tensorflow 2.x:
`tf.parse_single_example` is now `tf.io.parse_single_example`
`tf.FixedLenFeature` is now `tf.io.FixedLenFeature`
`tf.VarLenFeature` is now `tf.io.VarLenFeature`
`TFRecordDataset.make_one_shot_iterator()` is now `TFRecordDataset.__iter__()`
`tf.Session()` is deprecated and tf2 runs always eagerly
`TFRecord` needs to call `numpy()` before `decode()`