### PR TITLE
Fix generator

### DIFF
--- a/run.py
+++ b/run.py
@@ -56,16 +56,11 @@ def read_record(record_file):
     dataset = tf.data.TFRecordDataset([record_file])
     dataset = dataset.map(parse_func)
     iterator = dataset.__iter__()
-    next_element = next(iterator)
-    try:
-        while(True):
-            (image, image_format, height, width,
-             xmin, xmax, ymin, ymax, label) = next_element
-            yield (image.numpy(), image_format.numpy().decode('ascii'), height.numpy(),
-                    width.numpy(), xmin.numpy(), xmax.numpy(), ymin.numpy(), ymax.numpy(),
-                    label.numpy())
-    except tf.errors.OutOfRangeError:
-        pass
+    for item in iterator:
+        (image, image_format, height, width, xmin, xmax, ymin, ymax, label) = item
+        yield (image.numpy(), image_format.numpy().decode('ascii'), height.numpy(),
+                width.numpy(), xmin.numpy(), xmax.numpy(), ymin.numpy(), ymax.numpy(),
+                label.numpy())
 
 
 def make_train_val(train_records, val_records, images_dir,


### PR DESCRIPTION
The issue is that previously `next(iterator)` was only called *once*. So it retrieved the next item only once and then always returned the same image for the whole dataset. It should have been called inside the while loop. 

My change makes sure that the generator actually iterates over the whole dataset. 